### PR TITLE
runk: allow specifying gVisor platform (kvm, ptrace)

### DIFF
--- a/runk/runk.go
+++ b/runk/runk.go
@@ -42,6 +42,17 @@ type ProcessOpt struct {
 	Stdin          io.Reader
 }
 
+type GVisorPlatform string
+
+const (
+	KVM    GVisorPlatform = "kvm"
+	Ptrace                = "ptrace"
+)
+
+type GVisorOpt struct {
+	Platform GVisorPlatform
+}
+
 type Network int
 
 const (
@@ -53,6 +64,7 @@ type Opt struct {
 	Process ProcessOpt
 	Mounts  []string
 	Network Network
+	GVisor  GVisorOpt
 }
 
 func Run(o Opt) error {
@@ -65,7 +77,7 @@ func Run(o Opt) error {
 		return errors.Wrap(err, "error setting up memory usage")
 	}
 
-	p, err := newPlatform()
+	p, err := newPlatform(o.GVisor.Platform)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
By default, kvm is tried first then fallbacks to ptrace.

Signed-off-by: Tibor Vass <tibor@docker.com>